### PR TITLE
miatoll: Enable persist.vendor.radio.apm_sim_not_pwdn

### DIFF
--- a/vendor.prop
+++ b/vendor.prop
@@ -203,6 +203,7 @@ ro.vendor.extension_library=libqti-perfd-client.so
 # Radio
 persist.radio.multisim.config=dsds
 persist.vendor.radio.add_power_save=1
+persist.vendor.radio.apm_sim_not_pwdn=1
 persist.vendor.radio.custom_ecc=1
 persist.vendor.radio.data_con_rprt=1
 persist.vendor.radio.mt_sms_ack=30


### PR DESCRIPTION
Fixes dual sim preferences getting reset.